### PR TITLE
fix: fix android keyboard focus issue

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -14,7 +14,7 @@
         android:name=".MainActivity"
         android:label="@string/app_name"
         android:configChanges="keyboard|keyboardHidden|orientation|screenSize"
-        android:windowSoftInputMode="adjustResize">
+        android:windowSoftInputMode="adjustPan">
         <intent-filter>
             <action android:name="android.intent.action.MAIN" />
             <category android:name="android.intent.category.LAUNCHER" />


### PR DESCRIPTION
This PR fixes the issue on Android that the complete view is pushed to the top which is causing the focused input to disappear out of the view

**The issue:**
![android-issue](https://user-images.githubusercontent.com/11979740/51072003-5296e800-165a-11e9-9376-abc109d46db2.gif)

**The fix:**
![android-issue-fix](https://user-images.githubusercontent.com/11979740/51072006-59255f80-165a-11e9-9e36-2ce92a35bbd1.gif)
