### PR TITLE
Fix/stacknavigator

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9029,15 +9029,6 @@
       "resolved": "https://registry.npmjs.org/react-native-dismiss-keyboard/-/react-native-dismiss-keyboard-1.0.0.tgz",
       "integrity": "sha1-MohiQrPyMX4SHzrrmwpYXiuHm0k="
     },
-    "react-native-drawer": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/react-native-drawer/-/react-native-drawer-2.5.1.tgz",
-      "integrity": "sha512-cxcQNbSWy5sbGi7anSVp6EDr6JarOBMY9lbFOeLFeVYbONiudoqRKbgEsSDgSw3/LFCLvUXK5zdjXCOedeytxQ==",
-      "requires": {
-        "prop-types": "^15.5.8",
-        "tween-functions": "^1.0.1"
-      }
-    },
     "react-native-drawer-layout": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/react-native-drawer-layout/-/react-native-drawer-layout-1.3.2.tgz",
@@ -9153,6 +9144,16 @@
         "react-navigation-drawer": "0.5.0",
         "react-navigation-stack": "0.7.0",
         "react-navigation-tabs": "0.8.4"
+      },
+      "dependencies": {
+        "react-navigation-drawer": {
+          "version": "0.5.0",
+          "resolved": "https://registry.npmjs.org/react-navigation-drawer/-/react-navigation-drawer-0.5.0.tgz",
+          "integrity": "sha512-F1y593uC6pqBMGH+Omz75oNODEbxB/s0EGO8QtYwu1NmOOEUuuLA+c14zm+pgMsI4HlDabiHxPkWqsgGz25xVQ==",
+          "requires": {
+            "react-native-drawer-layout-polyfill": "^1.3.2"
+          }
+        }
       }
     },
     "react-navigation-deprecated-tab-navigator": {
@@ -9161,14 +9162,6 @@
       "integrity": "sha512-Cm+qYOPFWbvvcuv0YYX0ioYwLGgw7XAqdhAfpo3sIr3trxRW8871ePmfFOPezjQtz4v6ItjZt6LPgtBAVZoroQ==",
       "requires": {
         "react-native-tab-view": "^0.0.77"
-      }
-    },
-    "react-navigation-drawer": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/react-navigation-drawer/-/react-navigation-drawer-0.5.0.tgz",
-      "integrity": "sha512-F1y593uC6pqBMGH+Omz75oNODEbxB/s0EGO8QtYwu1NmOOEUuuLA+c14zm+pgMsI4HlDabiHxPkWqsgGz25xVQ==",
-      "requires": {
-        "react-native-drawer-layout-polyfill": "^1.3.2"
       }
     },
     "react-navigation-stack": {
@@ -11121,11 +11114,6 @@
       "requires": {
         "safe-buffer": "^5.0.1"
       }
-    },
-    "tween-functions": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/tween-functions/-/tween-functions-1.2.0.tgz",
-      "integrity": "sha1-GuOlDnxguz3vd06scHrLynO7w/8="
     },
     "tweetnacl": {
       "version": "0.14.5",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
     "i18n-js": "^3.1.0",
     "react": "16.6.0-alpha.8af6728",
     "react-native": "0.57.4",
-    "react-native-drawer": "2.5.1",
     "react-native-elements": "1.0.0-beta7",
     "react-native-languages": "^3.0.1",
     "react-native-modal-selector": "1.0.0",

--- a/src/js/Router.js
+++ b/src/js/Router.js
@@ -1,5 +1,8 @@
 import React, { Component } from 'react';
 import { createStackNavigator } from 'react-navigation';
+import AppHeader from './components/AppHeader';
+
+// The screens
 import Login from './screens/Login';
 import InventoryList from './screens/InventoryList';
 import InventoryItem from './screens/InventoryItem';
@@ -22,7 +25,11 @@ const Router = createStackNavigator({
     WebviewScreen: { screen: WebviewScreen },
   },
   {
-    headerMode: 'none',
+    initialRouteName: 'Login',
+    gesturesEnabled: false,
+    navigationOptions: ({ navigate, navigation }) => ({
+      header: (<AppHeader navigation={ navigation }/>),
+    }),
   });
 
 export default class NavigationContainer extends Component {

--- a/src/js/Router.js
+++ b/src/js/Router.js
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
-import { createStackNavigator } from 'react-navigation';
+import { createDrawerNavigator, createStackNavigator } from 'react-navigation';
 import AppHeader from './components/AppHeader';
+import { WINDOW_WIDTH } from './config/Constants';
 
 // The screens
 import Login from './screens/Login';
@@ -12,25 +13,46 @@ import CheckoutScreenTwo from './screens/CheckoutScreenTwo';
 import CheckoutComplete from './screens/CheckoutComplete';
 import WebviewSelection from './screens/WebviewSelection';
 import WebviewScreen from './screens/Webview';
+import DrawerLinks from './components/DrawerLinks';
 
-const Router = createStackNavigator({
-    Login: { screen: Login },
-    InventoryList: { screen: InventoryList },
-    InventoryItem: { screen: InventoryItem },
-    CartContents: { screen: CartContents },
-    CheckoutScreenOne: { screen: CheckoutScreenOne },
-    CheckoutScreenTwo: { screen: CheckoutScreenTwo },
-    CheckoutComplete: { screen: CheckoutComplete },
-    WebviewSelection: { screen: WebviewSelection },
-    WebviewScreen: { screen: WebviewScreen },
+export const SCREENS = {
+  LOGIN: 'Login',
+  INVENTORY_LIST: 'InventoryList',
+  INVENTORY_ITEM: 'InventoryItem',
+  CART_CONTENTS: 'CartContents',
+  CHECKOUT_SCREEN_ONE: 'CheckoutScreenOne',
+  CHECKOUT_SCREEN_TWO: 'CheckoutScreenTwo',
+  CHECKOUT_COMPLETE: 'CheckoutComplete',
+  WEBVIEW_SELECTION: 'WebviewSelection',
+  WEBVIEW_SCREEN: 'WebviewScreen',
+};
+
+const StackNavigator = createStackNavigator({
+    [SCREENS.LOGIN]: { screen: Login },
+    [SCREENS.INVENTORY_LIST]: { screen: InventoryList },
+    [SCREENS.INVENTORY_ITEM]: { screen: InventoryItem },
+    [SCREENS.CART_CONTENTS]: { screen: CartContents },
+    [SCREENS.CHECKOUT_SCREEN_ONE]: { screen: CheckoutScreenOne },
+    [SCREENS.CHECKOUT_SCREEN_TWO]: { screen: CheckoutScreenTwo },
+    [SCREENS.CHECKOUT_COMPLETE]: { screen: CheckoutComplete },
+    [SCREENS.WEBVIEW_SELECTION]: { screen: WebviewSelection },
+    [SCREENS.WEBVIEW_SCREEN]: { screen: WebviewScreen },
   },
   {
-    initialRouteName: 'Login',
-    gesturesEnabled: false,
+    initialRouteName: SCREENS.LOGIN,
     navigationOptions: ({ navigate, navigation }) => ({
       header: (<AppHeader navigation={ navigation }/>),
+      gesturesEnabled: false,
     }),
   });
+
+const Router = createDrawerNavigator({
+  StackNavigator: { screen: StackNavigator },
+}, {
+  contentComponent: DrawerLinks,
+  drawerWidth: WINDOW_WIDTH,
+  gesturesEnabled: false,
+});
 
 export default class NavigationContainer extends Component {
   render() {

--- a/src/js/components/AppHeader.js
+++ b/src/js/components/AppHeader.js
@@ -11,32 +11,13 @@ import { STATUS_BAR_HEIGHT } from './StatusBar';
 export default class AppHeader extends Component {
   constructor(props) {
     super(props);
-
-    this.state = {
-      menuOpen: false,
-    };
-
-    this.openMenu = this.openMenu.bind(this);
-    this.closeMenu = this.closeMenu.bind(this);
-  }
-
-  openMenu() {
-    this.setState({
-      menuOpen: true,
-    });
-  }
-
-  closeMenu() {
-    this.setState({
-      menuOpen: false,
-    });
   }
 
   render() {
     return (
       <Header
         containerStyle={ styles.header_container }
-        leftComponent={ <MenuButton openMenuHandler={ this.openMenu }/> }
+        leftComponent={ <MenuButton navigation={ this.props.navigation }/> }
         centerComponent={ <HeaderSwagLogo/> }
         rightComponent={ <CartButton navigation={ this.props.navigation }/> }
       />

--- a/src/js/components/DrawerLinks.js
+++ b/src/js/components/DrawerLinks.js
@@ -7,6 +7,7 @@ import { testProperties } from '../config/TestProperties';
 import { colors } from '../utils/colors';
 import { STATUS_BAR_HEIGHT } from './StatusBar';
 import { MUSEO_SANS_BOLD } from '../config/Constants';
+import { SCREENS } from '../Router';
 
 export default class DrawerLinks extends Component {
 
@@ -22,38 +23,34 @@ export default class DrawerLinks extends Component {
   }
 
   handleAllItemsLink() {
-    this.handleCloseMenu();
-    this.props.navigation.navigate('InventoryList');
+    this.props.navigation.closeDrawer();
+    this.props.navigation.navigate(SCREENS.INVENTORY_LIST);
   }
 
   handleWebviewLink() {
-    this.handleCloseMenu();
-    this.props.navigation.navigate('WebviewSelection');
+    this.props.navigation.closeDrawer();
+    this.props.navigation.navigate(SCREENS.WEBVIEW_SELECTION);
   }
 
   handleAboutLink() {
-
-    var aboutUrl = i18n.t('appHeader.url');
-    if (Credentials.isProblemUser()) {
-      aboutUrl = i18n.t('appHeader.404Url');
-    }
+    const aboutUrl =  i18n.t(Credentials.isProblemUser() ? 'appHeader.404Url' : 'appHeader.url');
 
     this.handleCloseMenu();
     Linking.openURL(aboutUrl);
   }
 
   handleLogoutLink() {
-    this.handleCloseMenu();
-    this.props.navigation.navigate('Login');
+    this.props.navigation.closeDrawer();
+    this.props.navigation.navigate(SCREENS.LOGIN);
   }
 
   handleResetLink() {
-    this.handleCloseMenu();
+    this.props.navigation.closeDrawer();
     ShoppingCart.resetCart();
   }
 
   handleCloseMenu() {
-    this.props.closeMenu();
+    this.props.navigation.closeDrawer();
   }
 
   render() {

--- a/src/js/components/HeaderCartButton.js
+++ b/src/js/components/HeaderCartButton.js
@@ -5,20 +5,12 @@ import { IS_IOS, MUSEO_SANS_NORMAL } from '../config/Constants';
 import { testProperties } from '../config/TestProperties';
 import i18n from '../config/i18n';
 import { colors } from '../utils/colors';
+import { SCREENS } from '../Router';
 
 export default class CartButton extends Component {
   constructor(props) {
     super(props);
     ShoppingCart.registerCartListener(this);
-
-    // Need to pass this in explicitly since it's a subcomponent
-    this.navigation = props.navigation;
-
-    this.navigateToShoppingCart = this.navigateToShoppingCart.bind(this);
-  }
-
-  navigateToShoppingCart() {
-    this.navigation.navigate('CartContents');
   }
 
   render() {
@@ -37,7 +29,7 @@ export default class CartButton extends Component {
 
     return (
       <View { ...testProperties(i18n.t('cart.label')) }>
-        <TouchableOpacity onPress={ this.navigateToShoppingCart }>
+        <TouchableOpacity onPress={ ()=> this.props.navigation.navigate(SCREENS.CART_CONTENTS) }>
           <Image
             style={ styles.cart_image }
             resizeMode="contain"

--- a/src/js/components/InventoryListItem.js
+++ b/src/js/components/InventoryListItem.js
@@ -3,6 +3,7 @@ import { ShoppingCart } from '../shopping-cart';
 import { Credentials } from '../credentials';
 import SwagGridItem from './SwagGridItem';
 import SwagRowItem from './SwagRowItem';
+import { SCREENS } from '../Router';
 
 export default class InventoryListItem extends Component {
   constructor(props) {
@@ -63,7 +64,7 @@ export default class InventoryListItem extends Component {
       itemId += 1;
     }
 
-    this.navigation.navigate('InventoryItem', { id: itemId });
+    this.navigation.navigate(SCREENS.INVENTORY_ITEM, { id: itemId });
   }
 
   render() {

--- a/src/js/components/InventoryListItemDetails.js
+++ b/src/js/components/InventoryListItemDetails.js
@@ -11,6 +11,7 @@ import {
   WINDOW_WIDTH,
 } from '../config/Constants';
 import { colors } from '../utils/colors';
+import { SCREENS } from '../Router';
 
 
 export default class InventoryListItemDetails extends Component {
@@ -43,7 +44,6 @@ export default class InventoryListItemDetails extends Component {
   }
 
   addToCart() {
-
     if (Credentials.isProblemUser()) {
       // Bail out now, don't add to cart if the item ID is odd
       if (this.state.id % 2 === 1) {
@@ -56,7 +56,6 @@ export default class InventoryListItemDetails extends Component {
   }
 
   removeFromCart() {
-
     if (Credentials.isProblemUser()) {
       // Bail out now, don't remove from cart if the item ID is even
       if (this.state.id % 2 === 0) {
@@ -69,18 +68,16 @@ export default class InventoryListItemDetails extends Component {
   }
 
   navigateToItem() {
-
-    var itemId = this.state.id;
+    let itemId = this.state.id;
     if (Credentials.isProblemUser()) {
       itemId += 1;
     }
 
-    this.navigation.navigate('InventoryItem', { id: itemId });
+    this.navigation.navigate(SCREENS.INVENTORY_ITEM, { id: itemId });
   }
 
   render() {
-
-    var cartButton;
+    let cartButton;
 
     if (ShoppingCart.isItemInCart(this.state.id)) {
       cartButton = (

--- a/src/js/components/MenuButton.js
+++ b/src/js/components/MenuButton.js
@@ -6,24 +6,14 @@ import i18n from '../config/i18n';
 export default class MenuButton extends Component {
   constructor(props) {
     super(props);
-
-    this.openMenu = this.openMenu.bind(this);
   }
 
-  openMenu() {
-    // Call a function provided by a parent component
-    if (this.props.openMenuHandler) {
-      this.props.openMenuHandler();
-    }
-  }
-
-  render () {
-
+  render() {
     return (
-      <View {...testProperties(i18n.t('menu.label'))}>
-        <TouchableOpacity onPress={this.openMenu}>
+      <View { ...testProperties(i18n.t('menu.label')) }>
+        <TouchableOpacity onPress={ () => this.props.navigation.openDrawer() }>
           <Image
-            style={styles.menu_image}
+            style={ styles.menu_image }
             resizeMode="contain"
             source={ require('../../img/menu-button.png') }
           />

--- a/src/js/components/SecondaryHeader.js
+++ b/src/js/components/SecondaryHeader.js
@@ -1,45 +1,23 @@
 import React, { Component } from 'react';
-import { StyleSheet } from 'react-native';
-import { Header } from 'react-native-elements';
-import CartButton from './HeaderCartButton.js';
-import MenuButton from './MenuButton.js';
-import HeaderSwagLogo from './HeaderSwagLogo';
-import { IS_IOS, MUSEO_SANS_BOLD } from '../config/Constants';
+import { View, StyleSheet, Text } from 'react-native';
 import { colors } from '../utils/colors';
+import { IS_IOS, MUSEO_SANS_BOLD } from '../config/Constants';
 import { STATUS_BAR_HEIGHT } from './StatusBar';
 
-export default class AppHeader extends Component {
+export default class SecondaryHeader extends Component {
   constructor(props) {
     super(props);
-
-    this.state = {
-      menuOpen: false,
-    };
-
-    this.openMenu = this.openMenu.bind(this);
-    this.closeMenu = this.closeMenu.bind(this);
-  }
-
-  openMenu() {
-    this.setState({
-      menuOpen: true,
-    });
-  }
-
-  closeMenu() {
-    this.setState({
-      menuOpen: false,
-    });
   }
 
   render() {
+    const headerText = this.props.header ? <Text style={ styles.header_title }>{ this.props.header }</Text> : null;
+    const component = this.props.component || null;
+
     return (
-      <Header
-        containerStyle={ styles.header_container }
-        leftComponent={ <MenuButton openMenuHandler={ this.openMenu }/> }
-        centerComponent={ <HeaderSwagLogo/> }
-        rightComponent={ <CartButton navigation={ this.props.navigation }/> }
-      />
+      <View style={ [ styles.secondary_header, (!headerText && !component) ? styles.bottom_border : {} ] }>
+        { headerText }
+        { component }
+      </View>
     );
   }
 }

--- a/src/js/screens/CartContents.js
+++ b/src/js/screens/CartContents.js
@@ -2,7 +2,6 @@ import React, { Component } from 'react';
 import { StyleSheet, View, ScrollView } from 'react-native';
 import { Divider, ThemeProvider } from 'react-native-elements';
 import { ShoppingCart } from '../shopping-cart.js';
-import AppHeader from '../components/AppHeader.js';
 import { InventoryData } from '../data/inventory-data.js';
 import i18n from '../config/i18n';
 import { testProperties } from '../config/TestProperties';
@@ -12,6 +11,7 @@ import { colors } from '../utils/colors';
 import ArrowButton from '../components/ArrowButton';
 import ProceedButton from '../components/ProceedButton';
 import SectionHeader from '../components/SectionHeader';
+import SecondaryHeader from '../components/SecondaryHeader';
 
 export default class CartContents extends Component {
   constructor(props) {
@@ -23,33 +23,29 @@ export default class CartContents extends Component {
 
     return (
       <ThemeProvider>
-        <AppHeader
-          navigation={ this.props.navigation }
-          header={ i18n.t('cartContent.header') }
+        <SecondaryHeader header={ i18n.t('cartContent.header') }/>
+        <SectionHeader/>
+        <ScrollView
+          style={ styles.container }
+          keyboardShouldPersistTaps="handled"
+          { ...testProperties(i18n.t('cartContent.screen')) }
         >
-          <SectionHeader/>
-          <ScrollView
-            style={ styles.container }
-            keyboardShouldPersistTaps="handled"
-            { ...testProperties(i18n.t('cartContent.screen')) }
-          >
-            <View style={ styles.cart_item_container }>
-              { contents.map((item, i) => <CartItem key={ i } item={ InventoryData.ITEMS[ item ] } showRemoveButton/>) }
-            </View>
-            <View style={ styles.button_container }>
-              <ArrowButton
-                title={ i18n.t('cartContent.continueShopping') }
-                onPress={ () => this.props.navigation.navigate('InventoryList') }
-              />
-              <Divider style={ styles.button_divider }/>
-              <ProceedButton
-                title={ i18n.t('cartContent.checkout') }
-                onPress={ () => this.props.navigation.navigate('CheckoutScreenOne') }
-              />
-            </View>
-            <Footer/>
-          </ScrollView>
-        </AppHeader>
+          <View style={ styles.cart_item_container }>
+            { contents.map((item, i) => <CartItem key={ i } item={ InventoryData.ITEMS[ item ] } showRemoveButton/>) }
+          </View>
+          <View style={ styles.button_container }>
+            <ArrowButton
+              title={ i18n.t('cartContent.continueShopping') }
+              onPress={ () => this.props.navigation.navigate('InventoryList') }
+            />
+            <Divider style={ styles.button_divider }/>
+            <ProceedButton
+              title={ i18n.t('cartContent.checkout') }
+              onPress={ () => this.props.navigation.navigate('CheckoutScreenOne') }
+            />
+          </View>
+          <Footer/>
+        </ScrollView>
       </ThemeProvider>
     );
   }

--- a/src/js/screens/CartContents.js
+++ b/src/js/screens/CartContents.js
@@ -12,6 +12,7 @@ import ArrowButton from '../components/ArrowButton';
 import ProceedButton from '../components/ProceedButton';
 import SectionHeader from '../components/SectionHeader';
 import SecondaryHeader from '../components/SecondaryHeader';
+import { SCREENS } from '../Router';
 
 export default class CartContents extends Component {
   constructor(props) {
@@ -36,12 +37,12 @@ export default class CartContents extends Component {
           <View style={ styles.button_container }>
             <ArrowButton
               title={ i18n.t('cartContent.continueShopping') }
-              onPress={ () => this.props.navigation.navigate('InventoryList') }
+              onPress={ () => this.props.navigation.navigate(SCREENS.INVENTORY_LIST) }
             />
             <Divider style={ styles.button_divider }/>
             <ProceedButton
               title={ i18n.t('cartContent.checkout') }
-              onPress={ () => this.props.navigation.navigate('CheckoutScreenOne') }
+              onPress={ () => this.props.navigation.navigate(SCREENS.CHECKOUT_SCREEN_ONE) }
             />
           </View>
           <Footer/>

--- a/src/js/screens/CheckoutComplete.js
+++ b/src/js/screens/CheckoutComplete.js
@@ -1,13 +1,13 @@
 import React, { Component } from 'react';
 import { StyleSheet, Text, View, ScrollView, Image } from 'react-native';
 import { ThemeProvider } from 'react-native-elements';
-import AppHeader from '../components/AppHeader.js';
 import { MUSEO_SANS_BOLD, MUSEO_SANS_NORMAL, WINDOW_WIDTH } from '../config/Constants';
 import i18n from '../config/i18n';
 import { testProperties } from '../config/TestProperties';
 import { colors } from '../utils/colors';
 import Footer from '../components/Footer';
 import ActionButton from '../components/ActionButton';
+import SecondaryHeader from '../components/SecondaryHeader';
 
 export default class CheckoutComplete extends Component {
   constructor(props) {
@@ -17,36 +17,32 @@ export default class CheckoutComplete extends Component {
   render() {
     return (
       <ThemeProvider>
-        <AppHeader
-          header={ i18n.t('checkoutCompletePage.header') }
-          navigation={ this.props.navigation }
+        <SecondaryHeader header={ i18n.t('checkoutCompletePage.header') }/>
+        <ScrollView
+          style={ styles.container }
+          keyboardShouldPersistTaps="handled"
+          { ...testProperties(i18n.t('checkoutCompletePage.screen')) }
         >
-          <ScrollView
-            style={ styles.container }
-            keyboardShouldPersistTaps="handled"
-            { ...testProperties(i18n.t('checkoutCompletePage.screen')) }
-          >
-            <View style={ styles.wrapper }>
+          <View style={ styles.wrapper }>
 
-              <View style={ styles.complete_container }>
-                <Text style={ styles.complete_title }>{ i18n.t('checkoutCompletePage.completeContainer.header') }</Text>
-                <Text style={ styles.complete_text }>{ i18n.t('checkoutCompletePage.completeContainer.text') }</Text>
-              </View>
-
-              <Image
-                resizeMode="contain"
-                source={ require('../../img/pony-express.png') }
-                style={ styles.ship_image }
-              />
-
-              <ActionButton
-                onPress={ () => this.props.navigation.navigate('InventoryList') }
-                title={ i18n.t('checkoutCompletePage.goToButton') }
-              />
+            <View style={ styles.complete_container }>
+              <Text style={ styles.complete_title }>{ i18n.t('checkoutCompletePage.completeContainer.header') }</Text>
+              <Text style={ styles.complete_text }>{ i18n.t('checkoutCompletePage.completeContainer.text') }</Text>
             </View>
-            <Footer/>
-          </ScrollView>
-        </AppHeader>
+
+            <Image
+              resizeMode="contain"
+              source={ require('../../img/pony-express.png') }
+              style={ styles.ship_image }
+            />
+
+            <ActionButton
+              onPress={ () => this.props.navigation.navigate('InventoryList') }
+              title={ i18n.t('checkoutCompletePage.goToButton') }
+            />
+          </View>
+          <Footer/>
+        </ScrollView>
       </ThemeProvider>
     );
   }

--- a/src/js/screens/CheckoutComplete.js
+++ b/src/js/screens/CheckoutComplete.js
@@ -8,6 +8,7 @@ import { colors } from '../utils/colors';
 import Footer from '../components/Footer';
 import ActionButton from '../components/ActionButton';
 import SecondaryHeader from '../components/SecondaryHeader';
+import { SCREENS } from '../Router';
 
 export default class CheckoutComplete extends Component {
   constructor(props) {
@@ -37,7 +38,7 @@ export default class CheckoutComplete extends Component {
             />
 
             <ActionButton
-              onPress={ () => this.props.navigation.navigate('InventoryList') }
+              onPress={ () => this.props.navigation.navigate(SCREENS.INVENTORY_LIST) }
               title={ i18n.t('checkoutCompletePage.goToButton') }
             />
           </View>

--- a/src/js/screens/CheckoutScreenOne.js
+++ b/src/js/screens/CheckoutScreenOne.js
@@ -2,19 +2,17 @@ import React, { Component } from 'react';
 import { StyleSheet, View, ScrollView } from 'react-native';
 import { ThemeProvider, Divider } from 'react-native-elements';
 import { Credentials } from '../credentials.js';
-import AppHeader from '../components/AppHeader.js';
 import i18n from '../config/i18n';
 import { testProperties } from '../config/TestProperties';
 import Footer from '../components/Footer';
 import { colors } from '../utils/colors';
 import ProceedButton from '../components/ProceedButton';
 import ArrowButton from '../components/ArrowButton';
-
 import ErrorMessageContainer from '../components/ErrorMessageContainer';
 import InputError from '../components/InputError';
+import SecondaryHeader from '../components/SecondaryHeader';
 
 export default class CheckoutScreenOne extends Component {
-
   constructor(props) {
     super(props);
 
@@ -101,57 +99,53 @@ export default class CheckoutScreenOne extends Component {
 
     return (
       <ThemeProvider>
-        <AppHeader
-          header={ i18n.t('checkoutPageOne.header') }
-          navigation={ this.props.navigation }
+        <SecondaryHeader header={ i18n.t('checkoutPageOne.header') }/>
+        <ScrollView
+          style={ styles.container }
+          keyboardShouldPersistTaps="handled"
+          { ...testProperties(i18n.t('checkoutPageOne.screen')) }
         >
-          <ScrollView
-            style={ styles.container }
-            keyboardShouldPersistTaps="handled"
-            { ...testProperties(i18n.t('checkoutPageOne.screen')) }
-          >
-            <View style={ styles.checkout_container }>
-              <InputError
-                placeholder={ 'checkoutPageOne.firstName' }
-                value={ this.state.firstName }
-                onChangeText={ this.handleFirstNameChange }
-                error={ this.state.firstNameError }
-              />
-              <Divider style={ styles.bottomMargin20 }/>
-              <InputError
-                placeholder={ 'checkoutPageOne.lastName' }
-                value={ this.state.lastName }
-                onChangeText={ this.handleLastNameChange }
-                error={ this.state.lastNameError }
-              />
-              <Divider style={ styles.bottomMargin20 }/>
-              <InputError
-                placeholder={ 'checkoutPageOne.postalCode' }
-                value={ this.state.postalCode }
-                onChangeText={ this.handlePostalCodeChange }
-                error={ this.state.postalCodeError }
-              />
-              <ErrorMessageContainer
-                testID={ i18n.t('checkoutPageOne.errors.container') }
-                message={ this.state.error }
-              />
-            </View>
-            <View style={ styles.button_container }>
-              <Divider style={ styles.divider }/>
+          <View style={ styles.checkout_container }>
+            <InputError
+              placeholder={ 'checkoutPageOne.firstName' }
+              value={ this.state.firstName }
+              onChangeText={ this.handleFirstNameChange }
+              error={ this.state.firstNameError }
+            />
+            <Divider style={ styles.bottomMargin20 }/>
+            <InputError
+              placeholder={ 'checkoutPageOne.lastName' }
+              value={ this.state.lastName }
+              onChangeText={ this.handleLastNameChange }
+              error={ this.state.lastNameError }
+            />
+            <Divider style={ styles.bottomMargin20 }/>
+            <InputError
+              placeholder={ 'checkoutPageOne.postalCode' }
+              value={ this.state.postalCode }
+              onChangeText={ this.handlePostalCodeChange }
+              error={ this.state.postalCodeError }
+            />
+            <ErrorMessageContainer
+              testID={ i18n.t('checkoutPageOne.errors.container') }
+              message={ this.state.error }
+            />
+          </View>
+          <View style={ styles.button_container }>
+            <Divider style={ styles.divider }/>
 
-              <ArrowButton
-                title={ i18n.t('checkoutPageOne.cancelButton') }
-                onPress={ () => this.props.navigation.navigate('InventoryList') }
-              />
-              <Divider style={ styles.button_divider }/>
-              <ProceedButton
-                title={ i18n.t('checkoutPageOne.continueButton') }
-                onPress={ this.handleSubmit }
-              />
-            </View>
-            <Footer/>
-          </ScrollView>
-        </AppHeader>
+            <ArrowButton
+              title={ i18n.t('checkoutPageOne.cancelButton') }
+              onPress={ () => this.props.navigation.navigate('InventoryList') }
+            />
+            <Divider style={ styles.button_divider }/>
+            <ProceedButton
+              title={ i18n.t('checkoutPageOne.continueButton') }
+              onPress={ this.handleSubmit }
+            />
+          </View>
+          <Footer/>
+        </ScrollView>
       </ThemeProvider>
     );
   }

--- a/src/js/screens/CheckoutScreenOne.js
+++ b/src/js/screens/CheckoutScreenOne.js
@@ -11,6 +11,7 @@ import ArrowButton from '../components/ArrowButton';
 import ErrorMessageContainer from '../components/ErrorMessageContainer';
 import InputError from '../components/InputError';
 import SecondaryHeader from '../components/SecondaryHeader';
+import { SCREENS } from '../Router';
 
 export default class CheckoutScreenOne extends Component {
   constructor(props) {
@@ -92,7 +93,7 @@ export default class CheckoutScreenOne extends Component {
     }
 
     // If we're here, we have our required info. Redirect!
-    this.props.navigation.navigate('CheckoutScreenTwo');
+    this.props.navigation.navigate(SCREENS.CHECKOUT_SCREEN_TWO);
   }
 
   render() {
@@ -136,7 +137,7 @@ export default class CheckoutScreenOne extends Component {
 
             <ArrowButton
               title={ i18n.t('checkoutPageOne.cancelButton') }
-              onPress={ () => this.props.navigation.navigate('InventoryList') }
+              onPress={ () => this.props.navigation.navigate(SCREENS.INVENTORY_LIST) }
             />
             <Divider style={ styles.button_divider }/>
             <ProceedButton

--- a/src/js/screens/CheckoutScreenTwo.js
+++ b/src/js/screens/CheckoutScreenTwo.js
@@ -3,7 +3,6 @@ import { StyleSheet, Text, View, ScrollView } from 'react-native';
 import { Divider, ThemeProvider } from 'react-native-elements';
 import { Credentials } from '../credentials.js';
 import { ShoppingCart } from '../shopping-cart.js';
-import AppHeader from '../components/AppHeader.js';
 import { InventoryData } from '../data/inventory-data.js';
 import i18n from '../config/i18n';
 import { testProperties } from '../config/TestProperties';
@@ -14,6 +13,7 @@ import { colors } from '../utils/colors';
 import Footer from '../components/Footer';
 import SectionHeader from '../components/SectionHeader';
 import CartItem from '../components/CartItem';
+import SecondaryHeader from '../components/SecondaryHeader';
 
 export default class CheckoutScreenTwo extends Component {
   constructor(props) {
@@ -49,56 +49,52 @@ export default class CheckoutScreenTwo extends Component {
 
     return (
       <ThemeProvider>
-        <AppHeader
-          header={ i18n.t('checkoutPageTwo.header') }
-          navigation={ this.props.navigation }
+        <SecondaryHeader header={ i18n.t('checkoutPageTwo.header') }/>
+        <SectionHeader/>
+        <ScrollView
+          style={ styles.container }
+          keyboardShouldPersistTaps="handled"
+          { ...testProperties(i18n.t('checkoutPageTwo.screen')) }
         >
-          <SectionHeader/>
-          <ScrollView
-            style={ styles.container }
-            keyboardShouldPersistTaps="handled"
-            { ...testProperties(i18n.t('checkoutPageTwo.screen')) }
-          >
-            <View style={ styles.cart_item_container }>
-              { contents.map((item, i) => <CartItem key={ i } item={ InventoryData.ITEMS[ item ] }/>) }
-            </View>
+          <View style={ styles.cart_item_container }>
+            { contents.map((item, i) => <CartItem key={ i } item={ InventoryData.ITEMS[ item ] }/>) }
+          </View>
 
-            <View style={ styles.summary_section }>
-              <Text style={ styles.summary_info_label }>{ i18n.t('checkoutPageTwo.summary.paymentLabel') }</Text>
-              <Text style={ styles.summary_value_label }>{ i18n.t('checkoutPageTwo.summary.card') }</Text>
-              <Divider style={ styles.divider }/>
-            </View>
+          <View style={ styles.summary_section }>
+            <Text style={ styles.summary_info_label }>{ i18n.t('checkoutPageTwo.summary.paymentLabel') }</Text>
+            <Text style={ styles.summary_value_label }>{ i18n.t('checkoutPageTwo.summary.card') }</Text>
+            <Divider style={ styles.divider }/>
+          </View>
 
-            <View style={ styles.summary_section }>
-              <Text style={ styles.summary_info_label }>{ i18n.t('checkoutPageTwo.summary.shippingLabel') }</Text>
-              <Text style={ styles.summary_value_label }>{ i18n.t('checkoutPageTwo.summary.shippingText') }</Text>
-              <Divider style={ styles.divider }/>
-            </View>
+          <View style={ styles.summary_section }>
+            <Text style={ styles.summary_info_label }>{ i18n.t('checkoutPageTwo.summary.shippingLabel') }</Text>
+            <Text style={ styles.summary_value_label }>{ i18n.t('checkoutPageTwo.summary.shippingText') }</Text>
+            <Divider style={ styles.divider }/>
+          </View>
 
-            <View style={ styles.summary_section }>
-              <Text style={ styles.summary_subtotal_label }>{ i18n.t('checkoutPageTwo.summary.itemsTotal') }${ orderTotal }</Text>
-              <Text style={ styles.summary_tax_label }>{ i18n.t('checkoutPageTwo.summary.itemsTax') }${ orderTax }</Text>
-              <Text style={ styles.summary_total_label }>
-                { i18n.t('checkoutPageTwo.summary.totalAmount') }${ (orderTotal + parseFloat(orderTax)).toFixed(2) }
-              </Text>
-              <Divider style={ styles.divider }/>
-            </View>
+          <View style={ styles.summary_section }>
+            <Text style={ styles.summary_subtotal_label }>{ i18n.t('checkoutPageTwo.summary.itemsTotal') }${ orderTotal }</Text>
+            <Text style={ styles.summary_tax_label }>{ i18n.t('checkoutPageTwo.summary.itemsTax') }${ orderTax }</Text>
+            <Text style={ styles.summary_total_label }>
+              { i18n.t('checkoutPageTwo.summary.totalAmount') }${ (orderTotal + parseFloat(orderTax)).toFixed(2) }
+            </Text>
+            <Divider style={ styles.divider }/>
+          </View>
 
-            <View style={ styles.button_container }>
-              <ArrowButton
-                title={ i18n.t('checkoutPageTwo.cancelButton') }
-                onPress={ () => this.props.navigation.navigate('InventoryList') }
-              />
-              <Divider style={ styles.button_divider }/>
-              <ProceedButton
-                title={ i18n.t('checkoutPageTwo.finishButton') }
-                onPress={ this.clearCart }
-              />
-            </View>
+          <View style={ styles.button_container }>
+            <ArrowButton
+              title={ i18n.t('checkoutPageTwo.cancelButton') }
+              onPress={ () => this.props.navigation.navigate('InventoryList') }
+            />
+            <Divider style={ styles.button_divider }/>
+            <ProceedButton
+              title={ i18n.t('checkoutPageTwo.finishButton') }
+              onPress={ this.clearCart }
+            />
+          </View>
 
-            <Footer/>
-          </ScrollView>
-        </AppHeader>
+          <Footer/>
+        </ScrollView>
       </ThemeProvider>
     );
   }

--- a/src/js/screens/CheckoutScreenTwo.js
+++ b/src/js/screens/CheckoutScreenTwo.js
@@ -14,6 +14,7 @@ import Footer from '../components/Footer';
 import SectionHeader from '../components/SectionHeader';
 import CartItem from '../components/CartItem';
 import SecondaryHeader from '../components/SecondaryHeader';
+import { SCREENS } from '../Router';
 
 export default class CheckoutScreenTwo extends Component {
   constructor(props) {
@@ -30,7 +31,7 @@ export default class CheckoutScreenTwo extends Component {
     }
 
     // Checkout complete, redirect to our order complete page
-    this.props.navigation.navigate('CheckoutComplete');
+    this.props.navigation.navigate(SCREENS.CHECKOUT_COMPLETE);
   }
 
   render() {
@@ -84,7 +85,7 @@ export default class CheckoutScreenTwo extends Component {
           <View style={ styles.button_container }>
             <ArrowButton
               title={ i18n.t('checkoutPageTwo.cancelButton') }
-              onPress={ () => this.props.navigation.navigate('InventoryList') }
+              onPress={ () => this.props.navigation.navigate(SCREENS.INVENTORY_LIST) }
             />
             <Divider style={ styles.button_divider }/>
             <ProceedButton

--- a/src/js/screens/InventoryItem.js
+++ b/src/js/screens/InventoryItem.js
@@ -3,13 +3,13 @@ import { StyleSheet, ScrollView } from 'react-native';
 import { ThemeProvider } from 'react-native-elements';
 import { Credentials } from '../credentials.js';
 import { ShoppingCart } from '../shopping-cart.js';
-import AppHeader from '../components/AppHeader.js';
 import { InventoryData } from '../data/inventory-data.js';
 import i18n from '../config/i18n';
 import { testProperties } from '../config/TestProperties';
 import InventoryListItemDetails from '../components/InventoryListItemDetails';
 import Footer from '../components/Footer';
 import ArrowButton from '../components/ArrowButton';
+import SecondaryHeader from '../components/SecondaryHeader';
 
 export default class InventoryItem extends Component {
   constructor(props) {
@@ -71,8 +71,7 @@ export default class InventoryItem extends Component {
   render() {
     return (
       <ThemeProvider>
-        <AppHeader
-          navigation={ this.props.navigation }
+        <SecondaryHeader
           component={
             <ArrowButton
               title={ i18n.t('inventoryItemPage.backButton') }
@@ -80,7 +79,7 @@ export default class InventoryItem extends Component {
               noBorders
             />
           }
-        >
+        />
           <ScrollView
             style={ styles.container }
             keyboardShouldPersistTaps="handled"
@@ -97,7 +96,6 @@ export default class InventoryItem extends Component {
             />
             <Footer/>
           </ScrollView>
-        </AppHeader>
       </ThemeProvider>
     );
   }

--- a/src/js/screens/InventoryItem.js
+++ b/src/js/screens/InventoryItem.js
@@ -10,6 +10,7 @@ import InventoryListItemDetails from '../components/InventoryListItemDetails';
 import Footer from '../components/Footer';
 import ArrowButton from '../components/ArrowButton';
 import SecondaryHeader from '../components/SecondaryHeader';
+import { SCREENS } from '../Router';
 
 export default class InventoryItem extends Component {
   constructor(props) {
@@ -41,7 +42,7 @@ export default class InventoryItem extends Component {
   }
 
   goBack() {
-    this.props.navigation.navigate('InventoryList');
+    this.props.navigation.navigate(SCREENS.INVENTORY_LIST);
   }
 
   addToCart() {

--- a/src/js/screens/InventoryList.js
+++ b/src/js/screens/InventoryList.js
@@ -3,7 +3,6 @@ import { StyleSheet, FlatList, View, ScrollView, Image, TouchableOpacity } from 
 import { ThemeProvider } from 'react-native-elements';
 import ModalSelector from 'react-native-modal-selector';
 import { InventoryData } from '../data/inventory-data.js';
-import AppHeader from '../components/AppHeader.js';
 import i18n from '../config/i18n';
 import { testProperties } from '../config/TestProperties';
 import { colors } from '../utils/colors';
@@ -11,6 +10,7 @@ import Footer from '../components/Footer';
 import InventoryListItem from '../components/InventoryListItem';
 import toggleRow from '../../img/toggle-row.png';
 import toggleGrid from '../../img/toggle-grid.png';
+import SecondaryHeader from '../components/SecondaryHeader';
 
 export default class InventoryList extends Component {
   constructor(props) {
@@ -146,38 +146,36 @@ export default class InventoryList extends Component {
 
     return (
       <ThemeProvider>
-        <AppHeader
-          navigation={ this.props.navigation }
+        <SecondaryHeader
           header={ i18n.t('inventoryListPage.header') }
           component={ headerButtons }
+        />
+        <ScrollView
+          style={ styles.container }
+          keyboardShouldPersistTaps="handled"
+          { ...testProperties(i18n.t('inventoryListPage.screen')) }
         >
-          <ScrollView
-            style={ styles.container }
-            keyboardShouldPersistTaps="handled"
-            { ...testProperties(i18n.t('inventoryListPage.screen')) }
-          >
-            <FlatList
-              data={ this.state.inventoryList }
-              keyExtractor={ this.keyExtractor }
-              key={ (this.state.gridView) ? 1 : 0 }
-              numColumns={ this.state.gridView ? 2 : 1 }
-              renderItem={ ({ item, index }) =>
-                <InventoryListItem
-                  key={ item.id }
-                  id={ item.id }
-                  image_url={ item.image_url }
-                  name={ item.name }
-                  desc={ item.desc }
-                  price={ item.price }
-                  navigation={ this.props.navigation }
-                  index={ index }
-                  gridView={ this.state.gridView }
-                />
-              }
-            />
-            <Footer/>
-          </ScrollView>
-        </AppHeader>
+          <FlatList
+            data={ this.state.inventoryList }
+            keyExtractor={ this.keyExtractor }
+            key={ (this.state.gridView) ? 1 : 0 }
+            numColumns={ this.state.gridView ? 2 : 1 }
+            renderItem={ ({ item, index }) =>
+              <InventoryListItem
+                key={ item.id }
+                id={ item.id }
+                image_url={ item.image_url }
+                name={ item.name }
+                desc={ item.desc }
+                price={ item.price }
+                navigation={ this.props.navigation }
+                index={ index }
+                gridView={ this.state.gridView }
+              />
+            }
+          />
+          <Footer/>
+        </ScrollView>
       </ThemeProvider>
     );
   }

--- a/src/js/screens/Login.js
+++ b/src/js/screens/Login.js
@@ -15,6 +15,9 @@ import InputError from '../components/InputError';
 import ErrorMessageContainer from '../components/ErrorMessageContainer';
 
 export default class Login extends Component {
+  static navigationOptions = {
+    header: null,
+  };
 
   constructor(props) {
     super(props);

--- a/src/js/screens/Login.js
+++ b/src/js/screens/Login.js
@@ -13,6 +13,7 @@ import { STATUS_BAR_HEIGHT } from '../components/StatusBar';
 import ActionButton from '../components/ActionButton';
 import InputError from '../components/InputError';
 import ErrorMessageContainer from '../components/ErrorMessageContainer';
+import { SCREENS } from '../Router';
 
 export default class Login extends Component {
   static navigationOptions = {
@@ -92,7 +93,7 @@ export default class Login extends Component {
       this.handlePassChange('');
       // and redirect after we wipe out any previous shopping cart contents
       ShoppingCart.resetCart();
-      this.props.navigation.navigate('InventoryList');
+      this.props.navigation.navigate(SCREENS.INVENTORY_LIST);
     } else {
       return this.setState({
         error: i18n.t('login.errors.noMatch'),

--- a/src/js/screens/Webview.js
+++ b/src/js/screens/Webview.js
@@ -1,11 +1,10 @@
 import React, { Component } from 'react';
 import { Image, StyleSheet, View, WebView } from 'react-native';
 import { ThemeProvider } from 'react-native-elements';
-import AppHeader from '../components/AppHeader';
 import { WINDOW_WIDTH } from '../config/Constants';
+import SecondaryHeader from '../components/SecondaryHeader';
 
 export default class WebViewScreen extends Component {
-
   renderLoading() {
     return (
       <View
@@ -23,15 +22,12 @@ export default class WebViewScreen extends Component {
   render() {
     return (
       <ThemeProvider>
-        <AppHeader
-          navigation={ this.props.navigation }
-        >
-          <WebView
-            renderLoading={ this.renderLoading }
-            source={ { uri: this.props.navigation.state.params.url } }
-            startInLoadingState
-          />
-        </AppHeader>
+        <SecondaryHeader/>
+        <WebView
+          renderLoading={ this.renderLoading }
+          source={ { uri: this.props.navigation.state.params.url } }
+          startInLoadingState
+        />
       </ThemeProvider>
     );
   }

--- a/src/js/screens/WebviewSelection.js
+++ b/src/js/screens/WebviewSelection.js
@@ -3,11 +3,11 @@ import { Keyboard, ScrollView, StyleSheet, View } from 'react-native';
 import { testProperties } from '../config/TestProperties';
 import { ThemeProvider } from 'react-native-elements';
 import i18n from '../config/i18n';
-import AppHeader from '../components/AppHeader';
 import Footer from '../components/Footer';
 import ErrorMessageContainer from '../components/ErrorMessageContainer';
 import InputError from '../components/InputError';
 import ActionButton from '../components/ActionButton';
+import SecondaryHeader from '../components/SecondaryHeader';
 
 export default class WebviewSelection extends Component {
   constructor(props) {
@@ -52,38 +52,34 @@ export default class WebviewSelection extends Component {
   render() {
     return (
       <ThemeProvider>
-        <AppHeader
-          navigation={ this.props.navigation }
-          header={ i18n.t('webview.screen') }
+        <SecondaryHeader header={ i18n.t('webview.screen') } />
+        <ScrollView
+          keyboardShouldPersistTaps="handled"
+          style={ styles.container }
+          { ...testProperties(i18n.t('webview.screen')) }
         >
-          <ScrollView
-            keyboardShouldPersistTaps="handled"
-            style={ styles.container }
-            { ...testProperties(i18n.t('webview.screen')) }
-          >
-            <View style={ [ styles.webview_container, styles.container_padding ] }>
-              <InputError
-                autoCapitalize="none"
-                autoCorrect={ false }
-                placeholder={ 'webview.placeholder' }
-                value={ this.state.siteUrl }
-                onChangeText={ this.setSiteUrl }
-                error={ this.state.error }
-              />
-              <ErrorMessageContainer
-                testID={ i18n.t('webview.errorContainer') }
-                message={ this.state.urlError }
-              />
-            </View>
-            <View style={ [ styles.container_padding, styles.button_container ] }>
-              <ActionButton
-                onPress={ this.handleSubmit }
-                title={ i18n.t('webview.go') }
-              />
-            </View>
-            <Footer/>
-          </ScrollView>
-        </AppHeader>
+          <View style={ [ styles.webview_container, styles.container_padding ] }>
+            <InputError
+              autoCapitalize="none"
+              autoCorrect={ false }
+              placeholder={ 'webview.placeholder' }
+              value={ this.state.siteUrl }
+              onChangeText={ this.setSiteUrl }
+              error={ this.state.error }
+            />
+            <ErrorMessageContainer
+              testID={ i18n.t('webview.errorContainer') }
+              message={ this.state.urlError }
+            />
+          </View>
+          <View style={ [ styles.container_padding, styles.button_container ] }>
+            <ActionButton
+              onPress={ this.handleSubmit }
+              title={ i18n.t('webview.go') }
+            />
+          </View>
+          <Footer/>
+        </ScrollView>
       </ThemeProvider>
     );
   }

--- a/src/js/screens/WebviewSelection.js
+++ b/src/js/screens/WebviewSelection.js
@@ -8,6 +8,7 @@ import ErrorMessageContainer from '../components/ErrorMessageContainer';
 import InputError from '../components/InputError';
 import ActionButton from '../components/ActionButton';
 import SecondaryHeader from '../components/SecondaryHeader';
+import { SCREENS } from '../Router';
 
 export default class WebviewSelection extends Component {
   constructor(props) {
@@ -31,7 +32,7 @@ export default class WebviewSelection extends Component {
       this.resetState();
       Keyboard.dismiss();
 
-      return this.props.navigation.navigate('WebviewScreen', { url: url });
+      return this.props.navigation.navigate(SCREENS.WEBVIEW_SCREEN, { url: url });
     } else {
       return this.setState({
         error: true,

--- a/tests/e2e/spec/checkout.page.one.spec.js
+++ b/tests/e2e/spec/checkout.page.one.spec.js
@@ -45,21 +45,18 @@ describe('Checkout: Your info', () => {
   it('should show an error when the first name has not been entered', () => {
     CheckoutPageOne.submitPersonalInfo(PERSONAL_INFO.NO_FIRSTNAME);
 
-    expect(CheckoutPageOne.isErrorMessageShown()).toEqual(true, 'The error message should be diplayed');
     expect(CheckoutPageOne.getErrorMessage()).toContain(SELECTORS.checkoutPageOne.errors.firstName, 'The error message is not as expected');
   });
 
   it('should show an error when the last name has not been entered', () => {
     CheckoutPageOne.submitPersonalInfo(PERSONAL_INFO.NO_LAST_NAME);
 
-    expect(CheckoutPageOne.isErrorMessageShown()).toEqual(true, 'The error message should be diplayed');
     expect(CheckoutPageOne.getErrorMessage()).toContain(SELECTORS.checkoutPageOne.errors.lastName, 'The error message is not as expected');
   });
 
   it('should show an error when the postal code has not been entered', () => {
     CheckoutPageOne.submitPersonalInfo(PERSONAL_INFO.NO_POSTAL_CODE);
 
-    expect(CheckoutPageOne.isErrorMessageShown()).toEqual(true, 'The error message should be diplayed');
     expect(CheckoutPageOne.getErrorMessage()).toContain(SELECTORS.checkoutPageOne.errors.postalCode, 'The error message is not as expected');
   });
 });

--- a/tests/e2e/spec/menu.spec.js
+++ b/tests/e2e/spec/menu.spec.js
@@ -42,7 +42,7 @@ describe('Menu', () => {
     Menu.open();
     Menu.openWebview();
 
-    expect(Webview.isShown()).toEqual(true, 'Webview page is not shown');
+    expect(Webview.input.isDisplayed()).toEqual(true, 'Webview page is not shown');
   });
 
   it('should be able reset the app state', () => {


### PR DESCRIPTION
> **NOTE:** This PR merges to the Webview PR. When that one is merged then change it to the master

The current implementation of the navigation is not working properly.:

- switching between screens make the complete screen move like a card, instead of only making the content switch
- the menu is always shown between switching from screen B back to screen A
- the drawer component that was used in this project was an extra dependency and was not fit for production / real use (they stated that on their own site)

This PR implements a smoother way of using the navigation between the screens, fixes not showing the menu between the screens by using the native drawer of React Navigation.

This PR holds a lot of changes, but is mainly to clean the code

## iOS
On the left you will see the old implementation, on the right the new

![ios-old](https://user-images.githubusercontent.com/11979740/53652870-2d7e2900-3c4a-11e9-9d94-00d4f5c9fd5f.gif) ![ios-new](https://user-images.githubusercontent.com/11979740/53652879-35d66400-3c4a-11e9-9668-d6dc3f6a6f7a.gif)


## Android
On the left you will see the old implementation, on the right the new

![android-old](https://user-images.githubusercontent.com/11979740/53652901-4a1a6100-3c4a-11e9-8503-e25e53482187.gif) ![android-new](https://user-images.githubusercontent.com/11979740/53652910-4e467e80-3c4a-11e9-8603-3d3cc2bfba97.gif)
